### PR TITLE
Feature/and or

### DIFF
--- a/src/hooks/foogle/foogle.ts
+++ b/src/hooks/foogle/foogle.ts
@@ -1,38 +1,64 @@
-import { Hook } from '../../utils/hook';
-import { DiscordService } from '../../services/app/discord_service';
-import { Client } from 'discord.js';
+import { Client, Message } from "discord.js";
+import { DiscordService } from "../../services/app/discord_service";
+import { FuckOffThrottleStrategyService } from "../../services/throttle/fuckOffThrottleStrategy.service";
+import { throttle } from "../../services/throttle/throttle";
+import { Hook } from "../../utils/hook";
+import { FuckOffStateManager } from "../fuckoff/fuckoff";
 
 const lmgtfyTemplate = "https://lmgtfy.com/?q=";
-const hotword = '@google';
+const hotword = "@google";
 const responses = [
   "Here's what I found",
   "This is what I can find",
 ];
+
+interface FireParams {
+  message: Message;
+}
 
 /** Fake Google that just LMGTFYs whatever you look up */
 /** This hook is not associated with Google in any way */
 export class FoogleHook implements Hook {
   private readonly client: Client;
 
-  constructor(private readonly discordService: DiscordService) {
+  constructor(
+    private readonly discordService: DiscordService,
+    private readonly fuckOffThrottleStrategyService: FuckOffThrottleStrategyService<FireParams>,
+    ) {
     this.client = this.discordService.getClient();
+  }
+
+  private fire = (params: FireParams) => {
+    const { message } = params;
+    const toEncode = message.content.slice(hotword.length).trim();
+    if (toEncode.length === 0) {
+      return;
+    }
+    const encodedURI = encodeURIComponent(toEncode);
+    const response = responses[Math.floor(Math.random() * responses.length)];
+    message.reply({
+      embed: {
+        description: `[${response}](${lmgtfyTemplate}${encodedURI})`,
+      },
+    });
   }
 
   async init() {
     const { client } = this;
 
-    client.on("message", (msg) => {
-      if (msg.content.indexOf(hotword) === 0) {
-        const toEncode = msg.content.slice(hotword.length).trim();
-        if (toEncode.length === 0)
-          return;
-        const encodedURI = encodeURIComponent(toEncode);
-        const response = responses[Math.floor(Math.random() * responses.length)];
-        msg.reply({
-          embed: {
-            description: `[${response}](${lmgtfyTemplate}${encodedURI})`,
-          },
-        });
+    const throttledFire = throttle({
+      fire: this.fire,
+      throttleStrategies: [
+        this.fuckOffThrottleStrategyService.getStrategy({
+          hookId: "foogle",
+          shouldFire: FuckOffStateManager.shouldFire,
+        }),
+      ],
+    });
+
+    client.on("message", (message) => {
+      if (message.content.indexOf(hotword) === 0) {
+        throttledFire({ message });
       }
     });
   }

--- a/src/hooks/fuckoff/fuckoff.ts
+++ b/src/hooks/fuckoff/fuckoff.ts
@@ -1,0 +1,85 @@
+import { Client } from "discord.js";
+import { DiscordService } from "../../services/app/discord_service";
+import { OnOffOpts } from "../../services/throttle/fuckOffThrottleStrategy.service";
+import { Hook } from "../../utils/hook";
+
+const hookIds = [
+  "foogle",
+  "replybot",
+];
+
+interface FuckOffStatus {
+  userId: string;
+  hookId: string;
+  isActive: boolean;
+}
+
+const FuckOffState: { [id: string]: FuckOffStatus } = {};
+
+export const FuckOffStateManager = {
+  /** tell a bot to fuck off for good */
+  fuckOff: (opts: OnOffOpts) => {
+    const { hookId, userId } = opts;
+    FuckOffState[userId + "." + hookId] = { 
+      userId,
+      hookId,
+      isActive: false
+    };
+  },
+  /** tell a bot to turn back on */
+  turnOn: (opts: OnOffOpts) => {
+    const { hookId, userId } = opts;
+    FuckOffState[userId + "." + hookId] = { 
+      userId,
+      hookId,
+      isActive: true
+    };
+  },
+  /** whether or not a bot was told to fuck off */
+  shouldFire: (opts: OnOffOpts) => {
+    const { hookId, userId } = opts;
+    const status = FuckOffState[userId + "." + hookId];
+    return status === undefined || status.isActive;
+  },
+};
+
+export class FuckOffHook implements Hook {
+  private readonly client: Client;
+
+  constructor(
+    private readonly discordService: DiscordService,
+  ) {
+    this.client = this.discordService.getClient();
+  }
+
+  public async init() {
+    this.client.on("message", (msg) => {
+      if (msg.channel.type !== "text") {
+        return;
+      }
+      if (msg.author.bot === true) {
+        return;
+      }
+      const userId = msg.author.username;
+      const text = msg.content.toLowerCase();
+      const hookId = hookIds.find(id => text.includes(id));
+      if (hookId === undefined) {
+        return;
+      }
+      if (/^fuck ?off/.test(text)) {
+        FuckOffStateManager.fuckOff({
+          hookId,
+          userId,
+        });
+        msg.reply("ok, ok, fucking off");
+      }
+      if ([/^we're cool/, /^we're good/].some(regx => regx.test(text))) {
+        FuckOffStateManager.turnOn({
+          hookId,
+          userId,
+        });
+        msg.reply("back in business, baby!");
+      }
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import { DateService } from "./services/core/date.service";
 import { CountThrottleStrategyService } from "./services/throttle/countThrottleStrategy.service";
 import { TimeThrottleStrategyService } from "./services/throttle/timeThrottleStrategy.service";
 import { ServiceRegistrySingleton } from "./utils/service_registry";
+import { OrThrottleStrategyService } from "./services/throttle/orThrottleStrategy.service";
+import { AndThrottleStrategyService } from "./services/throttle/andThrottleStrategy.service";
 
 const ENABLED_HOOKS = [
     "acromeanHook",
@@ -48,6 +50,8 @@ function registerServices() {
     ServiceRegistrySingleton.addService("dateService", DateService);
     ServiceRegistrySingleton.addService("countThrottleStrategyService", CountThrottleStrategyService);
     ServiceRegistrySingleton.addService("timeThrottleStrategyService", TimeThrottleStrategyService);
+    ServiceRegistrySingleton.addService("andThrottleStrategyService", AndThrottleStrategyService);
+    ServiceRegistrySingleton.addService("orThrottleStrategyService", OrThrottleStrategyService);
 
     ServiceRegistrySingleton.addService("acromeanHook", AcromeanHook);
     ServiceRegistrySingleton.addService("bogovotoHook", BogoVotoHook);

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,13 @@ import { SampleHook } from "./hooks/sample-hook";
 import { SnapchatHook } from "./hooks/snapchat/snapchat";
 import { VersionHook } from "./hooks/version/version";
 import { WhatHook } from "./hooks/what/what";
+
+import { FuckOffHook } from "./hooks/fuckoff/fuckoff";
 import { DiscordService } from "./services/app/discord_service";
 import { HooksService } from "./services/app/hooks_service";
 import { DateService } from "./services/core/date.service";
 import { CountThrottleStrategyService } from "./services/throttle/countThrottleStrategy.service";
+import { FuckOffThrottleStrategyService } from "./services/throttle/fuckOffThrottleStrategy.service";
 import { TimeThrottleStrategyService } from "./services/throttle/timeThrottleStrategy.service";
 import { ServiceRegistrySingleton } from "./utils/service_registry";
 import { OrThrottleStrategyService } from "./services/throttle/orThrottleStrategy.service";
@@ -27,7 +30,8 @@ const ENABLED_HOOKS = [
     "sampleHook",
     "versionHook",
     "innovateHook",
-    "replybotHook"
+    "replybotHook",
+    "fuckOffHook",
 ];
 
 class Main {
@@ -52,6 +56,7 @@ function registerServices() {
     ServiceRegistrySingleton.addService("timeThrottleStrategyService", TimeThrottleStrategyService);
     ServiceRegistrySingleton.addService("andThrottleStrategyService", AndThrottleStrategyService);
     ServiceRegistrySingleton.addService("orThrottleStrategyService", OrThrottleStrategyService);
+    ServiceRegistrySingleton.addService("fuckOffThrottleStrategyService", FuckOffThrottleStrategyService);
 
     ServiceRegistrySingleton.addService("acromeanHook", AcromeanHook);
     ServiceRegistrySingleton.addService("bogovotoHook", BogoVotoHook);
@@ -63,6 +68,7 @@ function registerServices() {
     ServiceRegistrySingleton.addService("versionHook", VersionHook);
     ServiceRegistrySingleton.addService("innovateHook", InnovateHook);
     ServiceRegistrySingleton.addService("replybotHook", ReplybotHook);
+    ServiceRegistrySingleton.addService("fuckOffHook", FuckOffHook);
 }
 
 registerServices();

--- a/src/services/throttle/andThrottleStrategy.service.ts
+++ b/src/services/throttle/andThrottleStrategy.service.ts
@@ -1,0 +1,39 @@
+import { ThrottleStrategy, ThrottleStrategyService } from "./throttle";
+
+/**
+ * the options available to the consumers
+ * of your strategy.
+ */
+interface AndThrottleOptions<TFireFunctionParams> {
+  throttles: Array<ThrottleStrategy<TFireFunctionParams>>;
+}
+
+/** 
+ * This service is just a wrapper that allows you to use injected services
+ * inside a throttling strategy.
+ * 
+ * Strategy factory for calling your function only if all throttles meet
+ * firing criteria.
+ */
+export class AndThrottleStrategyService<TFireFunctionParams>
+  implements ThrottleStrategyService<AndThrottleOptions<TFireFunctionParams>, TFireFunctionParams> {
+  public getStrategy = (opts: AndThrottleOptions<TFireFunctionParams>) => {
+    /**
+     * This class is the actual throttling strategy, 
+     * where the logic goes.
+     */
+    class AndThrottle implements ThrottleStrategy<TFireFunctionParams> {
+      private throttles: Array<ThrottleStrategy<TFireFunctionParams>>;
+      constructor(opts: AndThrottleOptions<TFireFunctionParams>) {
+        this.throttles = opts.throttles;
+      }
+      public shouldFire = (params: TFireFunctionParams) =>
+        this.throttles.every(throttle => throttle.shouldFire(params));
+      public recordFire = (params: TFireFunctionParams) =>
+        this.throttles.forEach(throttle => throttle.recordFire(params));
+      public recordBlock = (params: TFireFunctionParams) =>
+        this.throttles.forEach(throttle => throttle.recordBlock(params));
+    }
+    return new AndThrottle(opts);
+  }
+}

--- a/src/services/throttle/countThrottleStrategy.service.ts
+++ b/src/services/throttle/countThrottleStrategy.service.ts
@@ -15,7 +15,7 @@ interface CountThrottleOptions {
  * Strategy factory for calling your function once out of every numCallsBeforeFiringAgain.
  */
 export class CountThrottleStrategyService implements ThrottleStrategyService<CountThrottleOptions> {
-  public getStrategy: (opts: CountThrottleOptions) => ThrottleStrategy<CountThrottleOptions> = (opts) => {
+  public getStrategy: (opts: CountThrottleOptions) => ThrottleStrategy<any> = (opts) => {
     /**
      * This class is the actual throttling strategy, 
      * where the logic goes.

--- a/src/services/throttle/fuckOffThrottleStrategy.service.ts
+++ b/src/services/throttle/fuckOffThrottleStrategy.service.ts
@@ -1,0 +1,55 @@
+import { Message } from "discord.js";
+import { ThrottleStrategy, ThrottleStrategyService } from "./throttle";
+
+interface RequiredFireFunctionParams {
+  message: Message;
+}
+
+export interface OnOffOpts {
+  userId: string;
+  hookId: string;
+}
+
+/**
+ * the options available to the consumers
+ * of your strategy.
+ */
+interface FuckOffThrottleOptions {
+  /** the id for the hook this throttle applies to */
+  hookId: string;
+  /** whether or not a bot was told to fuck off */
+  shouldFire: (opts: OnOffOpts) => boolean;
+}
+
+/** 
+ * This service is just a wrapper that allows you to use injected services
+ * inside a throttling strategy.
+ * 
+ * Strategy factory for calling your function only if the user
+ * didn't tell the bot to fuck off.
+ */
+export class FuckOffThrottleStrategyService<TFireFunctionParams extends RequiredFireFunctionParams>
+  implements ThrottleStrategyService<FuckOffThrottleOptions, TFireFunctionParams> {
+  public getStrategy: (opts: FuckOffThrottleOptions)
+    => ThrottleStrategy<TFireFunctionParams> = (opts) => {
+    /**
+     * This class is the actual throttling strategy, 
+     * where the logic goes.
+     */
+    class FuckOffThrottle implements ThrottleStrategy<TFireFunctionParams> {
+      private isActive: (opts: OnOffOpts) => boolean;
+      private hookId: string;
+      constructor(opts: FuckOffThrottleOptions) {
+        this.isActive = opts.shouldFire;
+        this.hookId = opts.hookId;
+      }
+      public shouldFire = (params: TFireFunctionParams) => this.isActive({
+        hookId: this.hookId,
+        userId: params.message.author.username,
+      })
+      public recordFire = (params: TFireFunctionParams) => ({});
+      public recordBlock = (params: TFireFunctionParams) => ({});
+    }
+    return new FuckOffThrottle(opts);
+  }
+}

--- a/src/services/throttle/orThrottleStrategy.service.ts
+++ b/src/services/throttle/orThrottleStrategy.service.ts
@@ -1,0 +1,39 @@
+import { ThrottleStrategy, ThrottleStrategyService } from "./throttle";
+
+/**
+ * the options available to the consumers
+ * of your strategy.
+ */
+interface OrThrottleOptions<TFireFunctionParams> {
+  throttles: Array<ThrottleStrategy<TFireFunctionParams>>; 
+}
+
+/** 
+ * This service is just a wrapper that allows you to use injected services
+ * inside a throttling strategy.
+ * 
+ * Strategy factory for calling your function only if any throttles meet
+ * firing criteria.
+ */
+export class OrThrottleStrategyService<TFireFunctionParams>
+  implements ThrottleStrategyService<OrThrottleOptions<TFireFunctionParams>, TFireFunctionParams> {
+  public getStrategy = (opts: OrThrottleOptions<TFireFunctionParams>) => {
+    /**
+     * This class is the actual throttling strategy, 
+     * where the logic goes.
+     */
+    class OrThrottle implements ThrottleStrategy<TFireFunctionParams> {
+      private throttles: Array<ThrottleStrategy<TFireFunctionParams>>;
+      constructor(opts: OrThrottleOptions<TFireFunctionParams>) {
+        this.throttles = opts.throttles;
+      }
+      public shouldFire = (params: TFireFunctionParams) =>
+        this.throttles.some(throttle => throttle.shouldFire(params))
+      public recordFire = (params: TFireFunctionParams) =>
+        this.throttles.forEach(throttle => throttle.recordFire(params))
+      public recordBlock = (params: TFireFunctionParams) =>
+        this.throttles.forEach(throttle => throttle.recordBlock(params))
+    }
+    return new OrThrottle(opts);
+  }
+}

--- a/src/services/throttle/throttle.ts
+++ b/src/services/throttle/throttle.ts
@@ -5,45 +5,45 @@
  * ThrottleStrategy classes in case you need 
  * to inject some dependency.
  */
-export interface ThrottleStrategyService<TOptions> {
-  getStrategy: (opts: TOptions) => ThrottleStrategy<TOptions>;
+export interface ThrottleStrategyService<TOptions, TFireFunctionParams = any> {
+  getStrategy: (opts: TOptions) => ThrottleStrategy<TFireFunctionParams>;
 }
 
 /** 
  * The required methods of a throttle strategy.
  */
-export interface ThrottleStrategy<T> {
-  shouldFire: () => boolean;
-  recordFire: () => void;
-  recordBlock: () => void;
+export interface ThrottleStrategy<TFireFunctionParams> {
+  shouldFire: (opts: TFireFunctionParams) => boolean;
+  recordFire: (opts: TFireFunctionParams) => void;
+  recordBlock: (opts: TFireFunctionParams) => void;
 }
 
-export type FireFunction = (...args: any[]) => any;
+export type FireFunction<T> = (opts: T) => any;
 
-export interface ThrottleOpts<T extends FireFunction> {
+export interface ThrottleOpts<TFireFunctionParams> {
   /** the method to call */
-  fire: T;
-  throttleStrategies: Array<ThrottleStrategy<any>>;
+  fire: FireFunction<TFireFunctionParams>;
+  throttleStrategies: Array<ThrottleStrategy<TFireFunctionParams>>;
 }
 
 /**
  * Returns a new function that only calls your original function 
  * when permitted by the passed ThrottleStrategy.
  */
-export const throttle = <T extends FireFunction>(opts: ThrottleOpts<T>) => {
+export const throttle = <T>(opts: ThrottleOpts<T>) => {
   const {
     fire,
     throttleStrategies
   } = opts;
 
-  const throttledFunction: FireFunction = (...args: any[]) => {
-    if (throttleStrategies.some(s => s.shouldFire())) {
-      throttleStrategies.forEach(s => s.recordFire());
-      return fire(...args);
+  const throttledFunction: FireFunction<T> = (opts: T) => {
+    if (throttleStrategies.some(s => s.shouldFire(opts))) {
+      throttleStrategies.forEach(s => s.recordFire(opts));
+      return fire(opts);
     } else {
-      throttleStrategies.forEach(s => s.recordBlock());
+      throttleStrategies.forEach(s => s.recordBlock(opts));
     }
   };
 
-  return throttledFunction as T;
+  return throttledFunction;
 };

--- a/src/services/throttle/timeThrottleStrategy.service.ts
+++ b/src/services/throttle/timeThrottleStrategy.service.ts
@@ -21,7 +21,7 @@ export class TimeThrottleStrategyService implements ThrottleStrategyService<Time
     private readonly dateService: DateService,
   ) {}
   
-  public getStrategy: (opts: TimeThrottleOptions) => ThrottleStrategy<TimeThrottleOptions> = (opts) => {
+  public getStrategy: (opts: TimeThrottleOptions) => ThrottleStrategy<any> = (opts) => {
     const dateService = this.dateService;
     /**
      * This class is the actual throttling strategy, 


### PR DESCRIPTION
### Changes
* change throttle signature to use a single `param` object instead of `...args: any[]` for better type tracking
* adds and/or throttles, which allow you to create arbitrarily nested throttling logic. Also allows you to read from the parameters of the `fire` function from within these throttles.
* adds a throttle that allows you to disable or enable a hook per user
* add this throttle to foogle
* add this throttle to replybot